### PR TITLE
Import Material Design icons with example

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ with us and a fast changing codebase.
 - [x] Set a page-wide [decorator][2] for better-looking Storybook pages
 - [x] Export package for production
 - [x] Export our Storybook as a [static app][0]
+- [x] Set up [Material Design icons][7] example
 - [ ] Check [addons][4] and see if there is anything helpful there
   - https://github.com/storybooks/storybook/blob/next/addons/storysource
   - https://github.com/storybooks/storybook/tree/master/addons/info
@@ -54,3 +55,4 @@ whole application (if needed and once it's built, it can be run by
 [4]: https://storybook.js.org/addons/addon-gallery/
 [5]: https://getbootstrap.com/docs/4.3/getting-started/theming/
 [6]: https://getbootstrap.com/docs/4.3/getting-started/theming/#importing
+[7]: https://material.io/tools/icons/?style=baseline

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -4,6 +4,13 @@
 // Bootstrap is defined through a huge number of variables. You can check them
 // all at https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
 
+/* Custom settings */
+.material-icons {
+  font-style: 1em;
+  vertical-align: middle;
+  margin-top: -0.2em;
+}
+
 $cardinal-red: #bd0013;
 
 $body-color: $cardinal-red;

--- a/src/stories/03-icons.js
+++ b/src/stories/03-icons.js
@@ -1,0 +1,30 @@
+import { storiesOf } from '@storybook/html';
+
+import '../app.js';
+
+storiesOf('Components', module)
+  .add('Icons', () => `
+    <div class="h1">
+        <i class="material-icons">face</i> Next to some title
+    </div>
+    <hr />
+    <div class="h2">
+        <i class="material-icons">face</i> Next to a subtitle
+    </div>
+    <hr />
+    <i class="material-icons">face</i> and some text next to it
+    <hr />
+    <span>
+        <i class="material-icons">face</i>
+        inside a span
+    </span>
+    <hr />
+    <button type="button" class="btn btn-primary">
+        <i class="material-icons">bookmark</i>
+        Progress
+    </button>
+    <button type="button" class="btn btn-success" style="font-weight: 700;">
+        <i class="material-icons">check</i>
+        SAVE
+    </button>
+  `);


### PR DESCRIPTION
Add simple Material Design icon example. @shrihari, play around with this branch locally, see if you approve of it. ✅
![image](https://user-images.githubusercontent.com/385232/54083490-9c4c3800-4356-11e9-890d-44ef7cfdaa27.png)
