### PR TITLE
Bump to bootstrap 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
-      "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "boxen": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
-    "bootstrap": "^4.2.1",
+    "bootstrap": "^4.3.1",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.7"
   }


### PR DESCRIPTION
Due to CVE-2019-8331 a XSS vulnerability has been found.
This PR upgrades from bootstrap 4.2.1 to 4.3.1
https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/