### PR TITLE
Add first buttons

### DIFF
--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -9,8 +9,8 @@
  * Note
  * ----
  * This file was customised simply to allow a more seamless and organic override
- * of some of Bootstraps defaults. Overriding mixins here, at the source,
- * allows us to directly affect the classes Bootstrap generates.
+ * of some of Bootstraps defaults. Overriding mixins here if necessary,
+ * at the source, allows us to directly affect the classes Bootstrap generates.
  *
  * @import "~bootstrap/scss/*";  // This is a Bootstrap import
  * @import "bootstrap/*";        // This is a BridgeU custom override import
@@ -141,11 +141,11 @@ sup {
   top: -.5em; }
 
 a {
-  color: #007bff;
+  color: #3a4456;
   text-decoration: none;
   background-color: transparent; }
   a:hover {
-    color: #0056b3;
+    color: #1b2028;
     text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
@@ -1687,7 +1687,7 @@ textarea.form-control {
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
   line-height: 1.5;
-  border-radius: 0.25rem;
+  border-radius: 9999px;
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
   @media (prefers-reduced-motion: reduce) {
     .btn {
@@ -2059,10 +2059,10 @@ fieldset:disabled a.btn {
 
 .btn-link {
   font-weight: 400;
-  color: #007bff;
+  color: #3a4456;
   text-decoration: none; }
   .btn-link:hover {
-    color: #0056b3;
+    color: #1b2028;
     text-decoration: underline; }
   .btn-link:focus, .btn-link.focus {
     text-decoration: underline;
@@ -2075,13 +2075,13 @@ fieldset:disabled a.btn {
   padding: 0.5rem 1rem;
   font-size: 1.25rem;
   line-height: 1.5;
-  border-radius: 0.3rem; }
+  border-radius: 9999px; }
 
 .btn-sm, .btn-group-sm > .btn {
   padding: 0.25rem 0.5rem;
   font-size: 0.875rem;
   line-height: 1.5;
-  border-radius: 0.2rem; }
+  border-radius: 9999px; }
 
 .btn-block {
   display: block;
@@ -2988,7 +2988,7 @@ input[type="button"].btn-block {
   line-height: 1;
   background-color: transparent;
   border: 2px solid transparent;
-  border-radius: 0.25rem; }
+  border-radius: 9999px; }
   .navbar-toggler:hover, .navbar-toggler:focus {
     text-decoration: none; }
 
@@ -3400,12 +3400,12 @@ input[type="button"].btn-block {
   padding: 0.5rem 0.75rem;
   margin-left: -2px;
   line-height: 1.25;
-  color: #007bff;
+  color: #3a4456;
   background-color: #fff;
   border: 2px solid #dee2e6; }
   .page-link:hover {
     z-index: 2;
-    color: #0056b3;
+    color: #1b2028;
     text-decoration: none;
     background-color: #e9ecef;
     border-color: #dee2e6; }

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -169,7 +169,7 @@ $danger:        $flamingo-red;
 // //
 // // Style anchor elements.
 
-// $link-color:                              theme-color("primary") !default;
+$link-color:                              $finch-blue;
 // $link-decoration:                         none !default;
 // $link-hover-color:                        darken($link-color, 15%) !default;
 // $link-hover-decoration:                   underline !default;

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -439,9 +439,9 @@ $font-family-sans-serif:      "Lato", sans-serif;
 // $btn-block-spacing-y:         .5rem !default;
 
 // // Allows for customizing button radius independently from global border radius
-// $btn-border-radius:           $border-radius !default;
-// $btn-border-radius-lg:        $border-radius-lg !default;
-// $btn-border-radius-sm:        $border-radius-sm !default;
+$btn-border-radius:           9999px;
+$btn-border-radius-lg:        9999px;
+$btn-border-radius-sm:        9999px;
 
 // $btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 

--- a/src/scss/bridgeu/_variables.scss
+++ b/src/scss/bridgeu/_variables.scss
@@ -15,3 +15,4 @@ $cardinal-red: #bd0013;
 $flamingo-red: #fb3f56;
 $parrot-green: #37b083;
 $pigeon-grey:  #808080;
+$finch-blue:   #3a4456;

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -4,11 +4,16 @@ import '../app.js';
 
 storiesOf('Form', module)
   .add('Buttons', () => `
-    <h5>Primary</h5>
-    <button type="button" class="btn btn-success">Save</button><br>
+    <h5>Primary Action</h5>
+    <button type="button" class="btn btn-success">Find schools</button>
+    <button type="button" class="btn btn-danger">Remove</button>
+    <button type="button" class="btn btn-disabled" disabled>Find schools</button>
 
-    <h5 class="mt-3">Secondary</h5>
-    <button type="button" class="btn btn-secondary">Cancel</button>
+    <h5 class="mt-3">Primary Action Large</h5>
+    <button type="button" class="btn btn-success btn-lg">Find schools</button>
+
+    <h5 class="mt-3">Primary Action Small</h5>
+    <button type="button" class="btn btn-success btn-sm">Find schools</button>
 
     <h5 class="mt-3">With icon</h5>
     <button type="button" class="btn btn-success"><i class="material-icons">bookmark</i> Save</button>

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -3,13 +3,14 @@ import { storiesOf } from '@storybook/html';
 import '../app.js';
 
 storiesOf('Form', module)
-  .add('Button - primary', () => `
-    <button type="button" class="btn btn-success">Save</button>
-  `)
-  .add('Button - secondary', () => `
+  .add('Buttons', () => `
+    <h5>Primary</h5>
+    <button type="button" class="btn btn-success">Save</button><br>
+
+    <h5 class="mt-3">Secondary</h5>
     <button type="button" class="btn btn-secondary">Cancel</button>
-  `)
-  .add('Button - with icon', () => `
+
+    <h5 class="mt-3">With icon</h5>
     <button type="button" class="btn btn-success"><i class="material-icons">bookmark</i> Save</button>
   `)
   .add('Text input - with label', () => `

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -4,16 +4,17 @@ import '../app.js';
 
 storiesOf('Form', module)
   .add('Buttons', () => `
-    <h5>Primary Action</h5>
-    <button type="button" class="btn btn-success">Find schools</button>
-    <button type="button" class="btn btn-danger">Remove</button>
-    <button type="button" class="btn btn-disabled" disabled>Find schools</button>
+    <h5>Buttons</h5>
+    <button type="button" class="btn btn-success">Success</button>
+    <button type="button" class="btn btn-danger">Danger</button>
 
-    <h5 class="mt-3">Primary Action Large</h5>
-    <button type="button" class="btn btn-success btn-lg">Find schools</button>
+    <h5 class="mt-3">Sizes</h5>
+    <button type="button" class="btn btn-success btn-lg">Large button</button>
+    <button type="button" class="btn btn-success btn-sm">Small button</button>
 
-    <h5 class="mt-3">Primary Action Small</h5>
-    <button type="button" class="btn btn-success btn-sm">Find schools</button>
+    <h5 class="mt-3">Disabled</h5>
+    <button type="button" class="btn btn-success" disabled>Success disabled</button>
+    <button type="button" class="btn btn-danger" disabled>Danger disabled</button>
 
     <h5 class="mt-3">With icon</h5>
     <button type="button" class="btn btn-success"><i class="material-icons">bookmark</i> Save</button>

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -7,6 +7,7 @@ storiesOf('Form', module)
     <h5>Buttons</h5>
     <button type="button" class="btn btn-success">Success</button>
     <button type="button" class="btn btn-danger">Danger</button>
+    <button type="button" class="btn btn-link">Link (or secondary)</button>
 
     <h5 class="mt-3">Sizes</h5>
     <button type="button" class="btn btn-success btn-lg">Large button</button>


### PR DESCRIPTION
### ~Review after https://github.com/BridgeU/bridget/pull/15~

~This PR's changes: https://github.com/BridgeU/bridget/pull/16/files/8d94b83..HEAD~

This pull request brings some of @doutatsu’s work on developing the new buttons into the base laid down on https://github.com/BridgeU/bridget/pull/14.

It brings simple changes to a few buttons, moving them to a more prominent page and changing their border radius. I say these changes are simple because they are clear from the design and they don’t depend on other measurements and units — unlike font sizes and paddings. Most of Bootstrap dimensions are dynamic and represented in either `em` or `rem`, but the design we’re developing can only deliver dimensions in `px`, so need to do some calculations to get the sizings right. I’m leaving that for a following PR.

![image](https://user-images.githubusercontent.com/385232/57323349-8a400900-70fd-11e9-9a10-f4c71b0c6203.png)

