### PR TITLE
Add simple version of FAB button

### DIFF
--- a/src/scss/bridgeu/_buttons.scss
+++ b/src/scss/bridgeu/_buttons.scss
@@ -1,3 +1,11 @@
 .btn {
   text-transform: uppercase;
 }
+
+// FAB (Floating Action Button)
+// https://material.io/design/components/buttons-floating-action-button.html
+.btn-fab {
+  font-weight: $font-weight-bold;
+  padding-left: 0.65em;
+  padding-right: 0.65em;
+}

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -19,6 +19,14 @@ storiesOf('Form', module)
 
     <h5 class="mt-3">With icon</h5>
     <button type="button" class="btn btn-success"><i class="material-icons">bookmark</i> Save</button>
+
+    <h5 class="mt-3">
+      <a href="https://material.io/design/components/buttons-floating-action-button.html">
+        FAB
+      </a> (Floating Action button)
+    </h5>
+    <button type="button" class="btn btn-success btn-fab"><i class="material-icons">add</i></button>
+    <button type="button" class="btn btn-danger btn-fab"><i class="material-icons">remove</i></button>
   `)
   .add('Text input - with label', () => `
     <div class="form-group">


### PR DESCRIPTION
Inspired by Material Design, this button won’t be really floating around on our app as Material intended. No problem in that, though.

This commit brings a simple, stripped-down version of it, without adding much fuss. If we need inspiration for a more complex version (only time will tell), we can look at: https://fezvrasta.github.io/bootstrap-material-design/docs/4.0/material-design/buttons/#floating-action

![image](https://user-images.githubusercontent.com/385232/57385160-d052a680-71a9-11e9-8250-6cbe6d5ae2d6.png)

**Note:** technically, these buttons are not _perfectly_ round. For the time being, I would like us not to spend time and CSS lines/bytes trying to make them pixel-perfect, since their sizing depends on font sizes and those are still being explored by Alex and Shri. 🙇 