### PR TITLE
Add custom radio buttons and checkboxes

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var indeterminateCheckbox = document.getElementById('indeterminateCheck');
+    if (indeterminateCheckbox) indeterminateCheckbox.indeterminate = true;
+  });
+</script>

--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -2567,8 +2567,8 @@ input[type="button"].btn-block {
   opacity: 0; }
   .custom-control-input:checked ~ .custom-control-label::before {
     color: #fff;
-    border-color: #007bff;
-    background-color: #007bff; }
+    border-color: #37b083;
+    background-color: #37b083; }
   .custom-control-input:focus ~ .custom-control-label::before {
     box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
   .custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
@@ -2614,8 +2614,8 @@ input[type="button"].btn-block {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"); }
 
 .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
-  border-color: #007bff;
-  background-color: #007bff; }
+  border-color: #37b083;
+  background-color: #37b083; }
 
 .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='%23fff' d='M0 2h4'/%3e%3c/svg%3e"); }
@@ -7033,6 +7033,45 @@ a.text-dark:hover, a.text-dark:focus {
 
 .btn {
   text-transform: uppercase; }
+
+.btn-fab {
+  font-weight: 700;
+  padding-left: 0.65em;
+  padding-right: 0.65em; }
+
+.chip {
+  color: #212529;
+  background-color: #e9e9e9;
+  border-color: #e9e9e9;
+  border-radius: 9999px;
+  color: #3a4456;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 75%;
+  padding: 0.25em 0.6em;
+  text-transform: uppercase;
+  vertical-align: baseline;
+  white-space: nowrap; }
+  .chip:hover {
+    color: #212529;
+    background-color: #d6d6d6;
+    border-color: #d0d0d0; }
+  .chip:focus, .chip.focus {
+    box-shadow: 0 0 0 0.2rem rgba(203, 204, 204, 0.5); }
+  .chip.disabled, .chip:disabled {
+    color: #212529;
+    background-color: #e9e9e9;
+    border-color: #e9e9e9; }
+  .chip:not(:disabled):not(.disabled):active, .chip:not(:disabled):not(.disabled).active,
+  .show > .chip.dropdown-toggle {
+    color: #212529;
+    background-color: #d0d0d0;
+    border-color: #c9c9c9; }
+    .chip:not(:disabled):not(.disabled):active:focus, .chip:not(:disabled):not(.disabled).active:focus,
+    .show > .chip.dropdown-toggle:focus {
+      box-shadow: 0 0 0 0.2rem rgba(203, 204, 204, 0.5); }
+  .chip + .chip {
+    margin-left: 0.25rem; }
 
 .material-icons {
   font-size: 1em;

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -535,7 +535,7 @@ $btn-border-radius-sm:        9999px;
 // $custom-control-label-disabled-color:           $gray-600 !default;
 
 // $custom-control-indicator-checked-color:        $component-active-color !default;
-// $custom-control-indicator-checked-bg:           $component-active-bg !default;
+$custom-control-indicator-checked-bg:           $radio-checkbox-checked-bg;
 // $custom-control-indicator-checked-disabled-bg:  rgba(theme-color("primary"), .5) !default;
 // $custom-control-indicator-checked-box-shadow:   none !default;
 // $custom-control-indicator-checked-border-color: $custom-control-indicator-checked-bg !default;
@@ -551,7 +551,7 @@ $btn-border-radius-sm:        9999px;
 // $custom-checkbox-indicator-border-radius:       $border-radius !default;
 // $custom-checkbox-indicator-icon-checked:        str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$custom-control-indicator-checked-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"), "#", "%23") !default;
 
-// $custom-checkbox-indicator-indeterminate-bg:           $component-active-bg !default;
+$custom-checkbox-indicator-indeterminate-bg:           $radio-checkbox-checked-bg;
 // $custom-checkbox-indicator-indeterminate-color:        $custom-control-indicator-checked-color !default;
 // $custom-checkbox-indicator-icon-indeterminate:         str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='#{$custom-checkbox-indicator-indeterminate-color}' d='M0 2h4'/%3e%3c/svg%3e"), "#", "%23") !default;
 // $custom-checkbox-indicator-indeterminate-box-shadow:   none !default;

--- a/src/scss/bridgeu/_variables.scss
+++ b/src/scss/bridgeu/_variables.scss
@@ -24,3 +24,8 @@ $finch-blue:   #3a4456;
 $chip-background-color: $london-grey;
 $chip-border-color: $london-grey;
 $chip-color: $finch-blue;
+
+
+// Checkboxes & Radios
+
+$radio-checkbox-checked-bg: $parrot-green;

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -98,38 +98,50 @@ storiesOf('Components', module)
 
       <div class="form-group">
         <legend class="col-form-label">Checkboxes</legend>
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="gridCheck1" checked>
-          <label class="form-check-label" for="gridCheck1">First checkbox</label>
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox" class="custom-control-input" id="customSelectedCheck" checked>
+          <label class="custom-control-label" for="customSelectedCheck">
+            Selected custom checkbox
+          </label>
         </div>
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="gridCheck2">
-          <label class="form-check-label" for="gridCheck2">Second checkbox</label>
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox" class="custom-control-input" id="customCheck2">
+          <label class="custom-control-label" for="customCheck2">
+            Unselected custom checkbox
+          </label>
         </div>
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="gridCheck3" disabled>
-          <label class="form-check-label" for="gridCheck3">Second checkbox</label>
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox" class="custom-control-input" id="customDisabledCheck" disabled>
+          <label class="custom-control-label" for="customDisabledCheck">
+            Disabled custom checkbox
+          </label>
+        </div>
+        <div class="custom-control custom-checkbox">
+          <input type="checkbox" class="custom-control-input" id="indeterminateCheck">
+          <label class="custom-control-label" for="indeterminateCheck">
+            Indeterminate custom checkbox (set by JavaScript)
+          </label>
         </div>
       </div>
 
       <fieldset class="form-group">
         <legend class="col-form-label">Radios</legend>
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
-          <label class="form-check-label" for="gridRadios1">
-            First radio
+        <div class="custom-control custom-radio">
+          <input type="radio" id="customSelectedRadio" name="customRadio" class="custom-control-input" checked>
+          <label class="custom-control-label" for="customSelectedRadio">
+            Selected custom radio
           </label>
         </div>
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
-          <label class="form-check-label" for="gridRadios2">
-            Second radio
+        <div class="custom-control custom-radio">
+          <input type="radio" id="customRadio2" name="customRadio" class="custom-control-input">
+          <label class="custom-control-label" for="customRadio2">
+            Unselected custom radio
           </label>
         </div>
-        <div class="form-check disabled">
-          <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios3" value="option3" disabled>
-          <label class="form-check-label" for="gridRadios3">
-            Third disabled radio
+        <div class="custom-control custom-radio">
+          <input type="radio" id="customDisabledRadio" name="customRadio" class="custom-control-input" disabled>
+          <label class="custom-control-label" for="customDisabledRadio">
+            Disabled custom radio
           </label>
         </div>
       </fieldset>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/385232/58627387-07126d00-82cf-11e9-974a-c8fec98671c8.png)

This pull request replaces the default checkboxes and radio buttons we had and introduces custom ones, following [Bootstrap’s own example][bootstrap-example]. Only the _checked status_ colour was changed, since Alex said he doesn’t see a green highlight on all components. For now, these are the only ones that require this hue.

More info at https://www.pivotaltracker.com/story/show/166351369

[bootstrap-example]: https://getbootstrap.com/docs/4.3/components/forms/#custom-forms