### PR TITLE
Add note to see indeterminate custom checkbox

### DIFF
--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -121,6 +121,10 @@ storiesOf('Components', module)
           <label class="custom-control-label" for="indeterminateCheck">
             Indeterminate custom checkbox (set by JavaScript)
           </label>
+          <small id="indeterminateHelp" class="form-text text-muted">
+            (<a href="javascript:window.location.reload(true)">refresh the page
+            </a> if you don’t see it)
+          </small>
         </div>
       </div>
 


### PR DESCRIPTION
You need to reload the page on the Form in order to run the custom JS that we have to turn the checkbox into the indeterminate state. Until we find a good way to run page-specific JavaScript, this looks good enough to me.

![image](https://user-images.githubusercontent.com/385232/58798135-b87c1000-85f9-11e9-982f-3e4c0a6f5797.png)
