### PR TITLE
Add Secondary navigation to Bridget

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,5 +2,23 @@
   document.addEventListener('DOMContentLoaded', function () {
     var indeterminateCheckbox = document.getElementById('indeterminateCheck');
     if (indeterminateCheckbox) indeterminateCheckbox.indeterminate = true;
+
+    var navTabs = document.getElementsByClassName('js-nav-tabs')[0];
+    if (navTabs) {
+      var navLinks = navTabs.getElementsByClassName('nav-link');
+      Array.prototype.forEach.call(navLinks, function (el) {
+        el.addEventListener('click', event => {
+          event.preventDefault();
+
+          var currentActive = navTabs.getElementsByClassName('active')[0];
+          if (currentActive) {
+            var reg = new RegExp('(^| )active($| )', 'g');
+            currentActive.className = currentActive.className.replace(reg, ' ');
+          }
+
+          el.className += ' active';
+        });
+      });
+    }
   });
 </script>

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -691,12 +691,12 @@ $custom-checkbox-indicator-indeterminate-bg:           $radio-checkbox-checked-b
 $nav-link-disabled-color:              $text-disabled-color;
 
 // $nav-tabs-border-color:             $gray-300 !default;
-// $nav-tabs-border-width:             $border-width !default;
+$nav-tabs-border-width:             $nav-tabs-tab-border-width;
 // $nav-tabs-border-radius:            $border-radius !default;
-// $nav-tabs-link-hover-border-color:  $gray-200 $gray-200 $nav-tabs-border-color !default;
+$nav-tabs-link-hover-border-color:  transparent;
 // $nav-tabs-link-active-color:        $gray-700 !default;
 // $nav-tabs-link-active-bg:           $body-bg !default;
-// $nav-tabs-link-active-border-color: $gray-300 $gray-300 $nav-tabs-link-active-bg !default;
+$nav-tabs-link-active-border-color: transparent transparent $nav-tabs-active-border-color;
 
 $nav-pills-border-radius:           $btn-border-radius;
 // $nav-pills-link-active-color:       $component-active-color !default;

--- a/src/scss/bridgeu/_navbar.scss
+++ b/src/scss/bridgeu/_navbar.scss
@@ -12,3 +12,23 @@
 .navbar-pills .show > .nav-item {
   background-color: rgba($black, .4);
 }
+
+//
+// Tabs
+//
+
+.nav-tabs {
+  $nav-tabs-bottom-divier-border-width: 1px;
+
+  border-bottom-width: $nav-tabs-bottom-divier-border-width;
+  text-transform: uppercase;
+
+  .nav-item {
+    margin-bottom: -$nav-tabs-bottom-divier-border-width;
+  }
+
+  .nav-link {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+}

--- a/src/scss/bridgeu/_variables.scss
+++ b/src/scss/bridgeu/_variables.scss
@@ -33,3 +33,10 @@ $chip-color: $finch-blue;
 // Checkboxes & Radios
 
 $radio-checkbox-checked-bg: $parrot-green;
+
+
+// Nav
+
+$nav-tabs-active-border-color: $flamingo-red;
+$nav-tabs-bottom-divider-border-width: 1px;
+$nav-tabs-tab-border-width: 4px;

--- a/src/stories/03-navigation.js
+++ b/src/stories/03-navigation.js
@@ -29,19 +29,30 @@ storiesOf('Navigation', module)
       </div>
     </nav>
   `)
-  .add('Secondary nav - dashboard', () => `
-    <nav class="nav">
-      <a class="nav-link active" href="#">Recommendations</a>
-      <a class="nav-link" href="#">Shortlists</a>
-      <a class="nav-link" href="#">Applications</a>
-    </nav>
-  `)
-  .add('Secondary nav - schools', () => `
-    <nav class="nav">
-      <a class="nav-link active" href="#"><i class="material-icons">search</i> Find Schools</a>
-      <a class="nav-link" href="#"><i class="material-icons">bookmark</i> Saved Schools</a>
-      <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Disabled</a>
-    </nav>
+  .add('Secondary nav - Tabs', () => `
+    <p>
+      Our own version of
+      <a href="https://getbootstrap.com/docs/4.3/components/navs/#tabs">
+        base navigation with tabs
+      </a>. These are not supposed to be used inside a <code>navbar</code>,
+      they are secondary navigation.
+      <br>
+      If the tab clicking is not working, please reload the page.
+    </p>
+
+    <ul class="nav nav-tabs js-nav-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" href="#">Active tab</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#">Default tab</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">
+          Disabled tab
+        </a>
+      </li>
+    </ul>
   `)
   .add('School cards', () => `
     <div class="card-deck">


### PR DESCRIPTION
This PR adds the secondary navigation [Tabs](https://getbootstrap.com/docs/4.0/components/navs/#tabs), these tabs are used in connect and campaigns, overwriting bootstrap component tabs.

| previous MVP | new MVP | Goal |
|:-:|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/4270980/60174881-fa1f6580-9809-11e9-95a2-8a86cb377fc7.png) | ![image](https://user-images.githubusercontent.com/385232/60193540-c2c3af80-982f-11e9-8485-61d20709e13b.png)|![image](https://user-images.githubusercontent.com/4270980/60175040-5aaea280-980a-11e9-981b-dbfb9970db76.png) |



