### PR TITLE
Update Colours page / Unify with atomic design guide

### DIFF
--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -5,7 +5,7 @@
 
 // // Color system
 
-// $white:    #fff !default;
+$white:    #fff !default;
 // $gray-100: #f8f9fa !default;
 // $gray-200: #e9ecef !default;
 // $gray-300: #dee2e6 !default;
@@ -15,7 +15,7 @@
 // $gray-700: #495057 !default;
 // $gray-800: #343a40 !default;
 // $gray-900: #212529 !default;
-// $black:    #000 !default;
+$black:    #000 !default;
 
 // $grays: () !default;
 // // stylelint-disable-next-line scss/dollar-variable-default
@@ -45,11 +45,11 @@
 // $teal:    #20c997 !default;
 // $cyan:    #17a2b8 !default;
 
-// $colors: () !default;
+ $colors: () !default;
 // // stylelint-disable-next-line scss/dollar-variable-default
-// $colors: map-merge(
-//   (
-//     "blue":       $blue,
+$colors: map-merge(
+   (
+//     "black":       $black,
 //     "indigo":     $indigo,
 //     "purple":     $purple,
 //     "pink":       $pink,
@@ -62,34 +62,45 @@
 //     "white":      $white,
 //     "gray":       $gray-600,
 //     "gray-dark":  $gray-800
-//   ),
-//   $colors
-// );
+   ),
+  $colors
+);
 
-// $primary:       $blue !default;
-$secondary:     $pigeon-grey;
+$primary:       $finch-blue;
+$secondary:     $cardinal-red;
 $success:       $parrot-green;
 // $info:          $cyan !default;
 // $warning:       $yellow !default;
 $danger:        $flamingo-red;
 // $light:         $gray-100 !default;
+$inactive: $inactive-gray;
 $dark:          $finch-blue;
 
-// $theme-colors: () !default;
+$dark-gray-1: $dark-gray-1;
+$dark-gray-2: $dark-gray-2;
+$dark-gray-3: $dark-gray-3;
+
+ $theme-colors: () !default;
 // // stylelint-disable-next-line scss/dollar-variable-default
-// $theme-colors: map-merge(
-//   (
+ $theme-colors: map-merge(
+   (
 //     "primary":    $primary,
 //     "secondary":  $secondary,
 //     "success":    $success,
 //     "info":       $info,
 //     "warning":    $warning,
 //     "danger":     $danger,
-//     "light":      $light,
-//     "dark":       $dark
-//   ),
-//   $theme-colors
-// );
+     "inactive": $inactive,
+     "light-gray-1": $light-gray-1,
+     "light-gray-2": $light-gray-2,
+     "dark-gray-1": $dark-gray-1,
+     "dark-gray-2": $dark-gray-2,
+     "dark-gray-3": $dark-gray-3,
+     "white":       $white,
+     "black":       $black
+   ),
+   $theme-colors
+ );
 
 // // Set a specific jump point for requesting color jumps
 // $theme-color-interval:      8% !default;

--- a/src/scss/bridgeu/_variables.scss
+++ b/src/scss/bridgeu/_variables.scss
@@ -19,6 +19,15 @@ $pigeon-grey:  #808080;
 $catbird-grey: #cccccc;
 $finch-blue:   #3a4456;
 
+$inactive-gray: #d5d5d5;
+
+$dark-gray-1: #3d3d3d;
+$dark-gray-2: #686c71;
+$dark-gray-3: #84898f;
+$light-gray-1: #b2bac4;
+$light-gray-2: #f8f8f8;
+
+$icon-resting: #263753;
 
 // Text/links
 $text-disabled-color: $catbird-grey;

--- a/src/stories/01-global.js
+++ b/src/stories/01-global.js
@@ -16,13 +16,51 @@ storiesOf('Global', module)
     <br />
   `)
   .add('Colors', () => `
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-primary text-white d-inline-block"></div><code>$primary</code> 
+    <h2> Brand Colors </h2>
+    <div class="d-flex justify-content-around">
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-primary text-white d-inline-block"></div><code>$primary</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-secondary text-white d-inline-block"></div><code>$secondary</code> 
+      </div>
     </div>
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-success text-white d-inline-block"></div><code>$success</code> 
+    <h2> Neutral Colors </h2>
+    <div class="row justify-content-around">
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-white text-white d-inline-block"></div><code>$white</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-light-gray-1 text-white d-inline-block"></div><code>$light-gray-1</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-light-gray-2 text-white d-inline-block"></div><code>$light-gray-2</code> 
+      </div>
     </div>
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-secondary text-white d-inline-block"></div><code>$secondary</code> 
+    <div class="row justify-content-around">
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-dark-gray-1 text-white d-inline-block"></div><code>$dark-gray-1</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-dark-gray-2 text-white d-inline-block"></div><code>$dark-gray-2</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-dark-gray-3 text-white d-inline-block"></div><code>$dark-gray-3</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-black text-white d-inline-block"></div><code>$black</code> 
+      </div>
+    </div>
+    <h2> Utility Colors </h2>
+    <div class="row justify-content-around">
+       <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-success text-white d-inline-block"></div><code>$success</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-danger text-white d-inline-block"></div><code>$danger</code> 
+      </div>
+      <div class="d-flex align-items-center mb-4">
+        <div class="p-4 mr-2 bg-inactive text-white d-inline-block"></div><code>$inactive</code> 
+      </div>
     </div>
   `);


### PR DESCRIPTION
Previously we had this page with some colour variables in Bridget:

![image](https://user-images.githubusercontent.com/1711055/60086218-f5d84700-973a-11e9-8075-505fe90d5f8a.png)

Having a previous work of colours made by the team:

```
$cardinal-red: #bd0013;
$flamingo-red: #fb3f56;
$parrot-green: #37b083;
$london-grey:  #e9e9e9;
$pigeon-grey:  #808080;
$catbird-grey: #cccccc;
$finch-blue:   #3a4456;

```

And some others proposed by Alex in the Atomic Design guide he is working on:

```
$inactive-gray: #d5d5d5;

$dark-gray-1: #3d3d3d;
$dark-gray-2: #686c71;
$dark-gray-3: #84898f;
$light-gray-1: #b2bac4;
$light-gray-2: #f8f8f8;

$icon-resting: #263753;

```

I've updated the colours/variable page with the colours got from the atomic design with the following shape:

![image](https://user-images.githubusercontent.com/1711055/60086301-202a0480-973b-11e9-9749-d881b712cf1d.png)

Also is worth to mention if is it worth to add some of them or which of them as `theme-colours` and `colours` in the mapping file in Bridget.

⚠️ This is a WIP for discussion, not intended to be merged as is, but I think a lot of feedback is appreciated. Colours by Alex are still refining so until I can confirm this, I'll standby it.