### PR TITLE
Export colour variables and display them as cards

### DIFF
--- a/.storybook/scss/cards.scss
+++ b/.storybook/scss/cards.scss
@@ -1,0 +1,14 @@
+//
+// Color sample cards
+//
+// Customisations for https://getbootstrap.com/docs/4.3/components/card/
+
+$color-sample-dimension: 200px;
+
+.storybook__card {
+  width: $color-sample-dimension;
+}
+
+.storybook__card-img-top {
+  height: $color-sample-dimension / 2;
+}

--- a/.storybook/storybook.scss
+++ b/.storybook/storybook.scss
@@ -1,0 +1,16 @@
+@import "../src/scss/bridgeu/variables.scss";
+@import "../src/scss/bootstrap/variables.scss";
+
+//
+// CSS customisations for Storybook demo purposes
+@import "scss/cards.scss";
+
+//
+// Export some of our own variables so we can import them on the JavaScript side
+// and use them for demo purposes. This will not be available on Bridget as an
+// npm package.
+:export {
+  cardinalRed: $cardinal-red;
+  flamingoRed: $flamingo-red;
+  finchBlue: $finch-blue;
+}

--- a/src/stories/01-global.js
+++ b/src/stories/01-global.js
@@ -1,6 +1,11 @@
 import { storiesOf } from '@storybook/html';
 
 import '../app.js';
+import {
+  cardinalRed,
+  flamingoRed,
+  finchBlue,
+} from '../../.storybook/storybook.scss'
 
 storiesOf('Global', module)
   .add('Typography', () => `
@@ -16,13 +21,27 @@ storiesOf('Global', module)
     <br />
   `)
   .add('Colors', () => `
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-primary text-white d-inline-block"></div><code>$primary</code> 
+    <h3>Brand colors</h3>
+
+    <div class="card storybook__card float-left mr-3">
+      <div class="card-img-top storybook__card-img-top" style="background: ${cardinalRed}"></div>
+      <div class="card-body">
+        <span class="card-text">${cardinalRed}</span>
+        <pre class="card-text font-weight-bold">$cardinal-red</pre>
+      </div>
     </div>
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-success text-white d-inline-block"></div><code>$success</code> 
+    <div class="card storybook__card float-left mr-3">
+      <div class="card-img-top storybook__card-img-top" style="background: ${flamingoRed}"></div>
+      <div class="card-body">
+        <span class="card-text">${flamingoRed}</span>
+        <pre class="card-text font-weight-bold">$flamingo-red</pre>
+      </div>
     </div>
-    <div class="d-flex align-items-center mb-4">
-      <div class="p-4 mr-2 bg-secondary text-white d-inline-block"></div><code>$secondary</code> 
+    <div class="card storybook__card float-left mr-3">
+      <div class="card-img-top storybook__card-img-top" style="background: ${finchBlue}"></div>
+      <div class="card-body">
+        <span class="card-text">${finchBlue}</span>
+        <pre class="card-text font-weight-bold">$finch-blue</pre>
+      </div>
     </div>
   `);

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -3,6 +3,8 @@ import { storiesOf } from '@storybook/html';
 
 import '../app.js';
 
+import '../../.storybook/storybook.scss';
+
 // storiesOf('Demo|Something', module)
 //   .add('heading', () => '<h1>Hello World</h1>')
 //   .add('button', () => {


### PR DESCRIPTION
Trying to set a direction in which to show/emulate our visual style guide, we’re trying to get a better sense of Atomic Design.

This commit introduces a simple way to directly tap into our Sass variables and bring them into the Storybook guide we have in order to show developers and designers our colour building blocks.

This PR brings some of the visual inspiration found at our [Atomic Design InVision board][invision-board] into our Storybook prototype.

|InVision prototype|Storybook guide|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/385232/60358756-eb35e000-99ce-11e9-99ef-0796305ec295.png)|![image](https://user-images.githubusercontent.com/385232/60358764-f2f58480-99ce-11e9-8f51-58abfffa324e.png)|

**Inspiration:** [How to share variables between JavaScript and Sass][share-variables-between-js-and-sass]
**Note:** As we’re going to start adding more information about colours, their context and their ideal usage, I believe we should morph them into [horizontal cards][horizontal-cards] for information density. Maybe something like [this][wfp-colors]…?

[invision-board]: https://projects.invisionapp.com/d/main#/console/17837187/369909099/preview
[share-variables-between-js-and-sass]: https://www.bluematador.com/blog/how-to-share-variables-between-js-and-sass
[horizontal-cards]: https://getbootstrap.com/docs/4.3/components/card/#horizontal
[wfp-colors]: https://cdn.wfp.org/guides/ui/v1.2.1/docs/?path=/story/documentation-general--colors