### PR TITLE
Add inline form example

### DIFF
--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -174,4 +174,20 @@ storiesOf('Components', module)
         </div>
       </fieldset>
     </form>
+
+    <br>
+
+    <h5>Inline form</h5>
+
+    <form class="form-inline">
+      <div class="form-group">
+        <label for="staticEmail2" class="sr-only">Email</label>
+        <input type="text" readonly class="form-control-plaintext" id="staticEmail2" value="email@example.com">
+      </div>
+      <div class="form-group mx-sm-3">
+        <label for="inputPassword2" class="sr-only">Password</label>
+        <input type="password" class="form-control" id="inputPassword2" placeholder="Password">
+      </div>
+      <button type="submit" class="btn btn-success">Confirm identity</button>
+    </form>
   `);


### PR DESCRIPTION
Shrihari pointed out quite well that inputs and buttons follow the same dimensions — height, specially — so it would be a good idea to have an input and button side by side to make sure we don’t break this relation.
![image](https://user-images.githubusercontent.com/385232/60431301-5e219f80-9bf7-11e9-848c-85abdc3d9e18.png)
