### PR TITLE
Remove uppercase transform on buttons

### DIFF
--- a/src/scss/bridgeu/_buttons.scss
+++ b/src/scss/bridgeu/_buttons.scss
@@ -1,7 +1,3 @@
-.btn {
-  text-transform: uppercase;
-}
-
 // FAB (Floating Action Button)
 // https://material.io/design/components/buttons-floating-action-button.html
 .btn-fab {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/385232/61226836-1b91b400-a71b-11e9-967d-619abd77a93f.png)

Alex and Shri asked for this to be removed. They think it’s simpler and easier to work without them. They also looked a bit “shouty”, so they’ll be “lighter” from now on.