### PR TITLE
Reset input border

### DIFF
--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -400,7 +400,7 @@ $font-family-sans-serif:      "Lato", sans-serif;
 // $input-btn-font-size-lg:      $font-size-lg !default;
 // $input-btn-line-height-lg:    $line-height-lg !default;
 
-$input-btn-border-width:      2px;
+// $input-btn-border-width:      $border-width !default;
 
 
 // // Buttons


### PR DESCRIPTION
This will reset buttons‘ and inputs‘ borders to Bootstrap‘s defaults.
This will bring buttons‘ heights to 38px as Alex and Shri asked for.
![image](https://user-images.githubusercontent.com/385232/61283949-de2e3480-a7b5-11e9-876e-166b9f22fade.png)
![image](https://user-images.githubusercontent.com/385232/61283957-e25a5200-a7b5-11e9-9925-c3b4b2cfbc61.png)
