### PR TITLE
Add headings

### DIFF
--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -275,7 +275,7 @@ $font-family-sans-serif:      "Lato", sans-serif;
 // $font-family-base:            $font-family-sans-serif !default;
 // // stylelint-enable value-keyword-case
 
-// $font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
+$font-size-base:              1rem !default; // Assumes the browser default, typically `16px`
 // $font-size-lg:                $font-size-base * 1.25 !default;
 // $font-size-sm:                $font-size-base * .875 !default;
 
@@ -288,9 +288,9 @@ $font-family-sans-serif:      "Lato", sans-serif;
 // $font-weight-base:            $font-weight-normal !default;
 // $line-height-base:            1.5 !default;
 
-// $h1-font-size:                $font-size-base * 2.5 !default;
-// $h2-font-size:                $font-size-base * 2 !default;
-// $h3-font-size:                $font-size-base * 1.75 !default;
+$h1-font-size:                $font-size-base * 3;    // `48px` assuming $font-size-base as `16px`
+$h2-font-size:                $font-size-base * 2.25; // `36px` assuming $font-size-base as `16px`
+$h3-font-size:                $font-size-base * 1.75; // `28px` assuming $font-size-base as `16px`
 // $h4-font-size:                $font-size-base * 1.5 !default;
 // $h5-font-size:                $font-size-base * 1.25 !default;
 // $h6-font-size:                $font-size-base !default;

--- a/src/stories/01-global.js
+++ b/src/stories/01-global.js
@@ -15,6 +15,12 @@ storiesOf('Global', module)
     <br />
     <h3 class="h3">h3. World-class university and careers guidance</h3>
     <br />
+    <h3 class="h4">h4. World-class university and careers guidance</h4>
+    <br />
+    <h3 class="h5">h5. World-class university and careers guidance</h5>
+    <br />
+    <h3 class="h6">h6. World-class university and careers guidance</h6>
+    <br />
     <p>
       <strong>Note:</strong> Just as
       <a class="underline" href="https://getbootstrap.com/docs/4.3/content/typography/"><u>Bootstrap provides</u></a>,

--- a/src/stories/01-global.js
+++ b/src/stories/01-global.js
@@ -9,16 +9,21 @@ import {
 
 storiesOf('Global', module)
   .add('Typography', () => `
-    <p class="">World-class university and careers guidance for global secondary schools</p>
+    <h1 class="h1">h1. World-class university and careers guidance</h1>
     <br />
-    <p class="">World-class university and careers guidance for global secondary schools</p>
+    <h2 class="h2">h2. World-class university and careers guidance</h2>
     <br />
-    <p class="">World-class university and careers guidance for global secondary schools</p>
+    <h3 class="h3">h3. World-class university and careers guidance</h3>
     <br />
-    <p class="">World-class university and careers guidance for global secondary schools</p>
-    <br />
-    <p class="">World-class university and careers guidance for global secondary schools</p>
-    <br />
+    <p>
+      <strong>Note:</strong> Just as
+      <a class="underline" href="https://getbootstrap.com/docs/4.3/content/typography/"><u>Bootstrap provides</u></a>,
+      we have styled <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code>
+      to allow us to use the most semantic elements whenever possible,
+      but the corresponding <code>.h1</code> through <code>.h6</code> classes
+      are also available, for when you want to match the font styling of a
+      heading but cannot use the associated HTML element.
+    </p>
   `)
   .add('Colors', () => `
     <h3>Brand colors</h3>


### PR DESCRIPTION
This pull request will add three new custom headings and three default ones:
- `<h1>` to `<h3>` have our own size, requested by design: 48, 36 and 28px
- `<h4>`to `<h6>` have the default size from Bootstrap, not customised/set yet (but it’s nice to add them for reference sake)

![image](https://user-images.githubusercontent.com/385232/62545137-052dd280-b859-11e9-9a4c-46193f782ba4.png)
