### PR TITLE
Change relative path for variables import

### DIFF
--- a/src/scss/bootstrap/bootstrap.scss
+++ b/src/scss/bootstrap/bootstrap.scss
@@ -17,7 +17,7 @@
 @import "~bootstrap/scss/functions";
 
 // Custom variables must be defined BEFORE Bootstrap's
-@import "../bridget/src/scss/bootstrap/variables";
+@import "variables";
 @import "~bootstrap/scss/variables";
 
 @import "~bootstrap/scss/mixins";


### PR DESCRIPTION
When adding `bridget` to the Prepare project,@MariaCheca & @abenitoc found that there was an error in CircleCI when trying to resolve the relative path `"../bridget/src/scss/bootstrap/variables"` [here](https://github.com/BridgeU/bridgeu/pull/6717). 

To resolve this issue we can fix the import by using a more typical scss convention. As both files, `_variables.scss` and `bootstrap.scss`, are in the same folder, `/scss/`, we can import with just the name of the file.