### PR TITLE
Disable global bootstrap shadows

### DIFF
--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -108,7 +108,7 @@ $dark:          $finch-blue;
 
 // $enable-caret:                                true !default;
 // $enable-rounded:                              true !default;
-$enable-shadows:                              true;
+// $enable-shadows:                              false !default;
 // $enable-gradients:                            false !default;
 // $enable-transitions:                          true !default;
 // $enable-prefers-reduced-motion-media-query:   true !default;

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -269,7 +269,7 @@ storiesOf('Components', module)
       <button class="btn btn-link dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         Saved Schools
       </button>
-      <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+      <div class="dropdown-menu shadow" aria-labelledby="dropdownMenuButton">
         <div class="dropdown-item d-flex justify-content-between align-items-center"><a href="#">Some school</a><i class="material-icons">delete</i></div>
         <a class="dropdown-item" href="#">Magical Mystery Schools<i class="material-icons">delete</i></a>
         <a class="dropdown-item" href="#">French International Schools</a>
@@ -295,7 +295,7 @@ storiesOf('Components', module)
     <div class="mb-5"></div>
 
     <h5>School discovery card</h5>
-    <div class="card">
+    <div class="card shadow-sm">
       <div class="card-body">
         <div class="d-flex justify-content-between">
           <div class="d-flex flex-column justify-content-center">
@@ -318,7 +318,7 @@ storiesOf('Components', module)
     <div class="mb-5"></div>
 
     <h5>Visits card</h5>
-    <div class="card">
+    <div class="card shadow-sm">
       <div class="card-body">
         <div class="d-flex justify-content-between align-items-center">
 


### PR DESCRIPTION
#50 enabled Bootstrap's global shadows because we wanted shadows for elements like Dropdowns and Cards. 

But the Bootstrap variable also enabled unwanted shadows like inset shadows on buttons, input fields etc. This PR reverts this change, and manually adds shadows on required components like Dropdowns and Cards. This gives us greater control on what shadows we add to what components.

Buttons before:
![image](https://user-images.githubusercontent.com/39978/73188325-9d2abb80-411a-11ea-9c9e-2291ed8b9d46.png)

Buttons after:
![image](https://user-images.githubusercontent.com/39978/73188348-a6b42380-411a-11ea-8ab0-036afe3bc8af.png)
