### PR TITLE
Add Tables with hoverable rows

### DIFF
--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -23,3 +23,4 @@
 @import 'bridgeu/icons';
 @import 'bridgeu/navbar';
 @import 'bridgeu/selects';
+@import 'bridgeu/tables';

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -15,7 +15,7 @@ $gray-600: #808080;
 $gray-700: #666666;
 $gray-800: #4D4D4D;
 $gray-900: #333333;
-// $black:    #000 !default;
+$black:    #000;
 
 // $grays: () !default;
 // // stylelint-disable-next-line scss/dollar-variable-default
@@ -352,7 +352,7 @@ $h3-font-size:                $font-size-base * 1.75; // `28px` assuming $font-s
 // $table-bg:                    null !default;
 // $table-accent-bg:             rgba($black, .05) !default;
 // $table-hover-color:           $table-color !default;
-// $table-hover-bg:              rgba($black, .075) !default;
+$table-hover-bg:              rgba($black, .05);
 // $table-active-bg:             $table-hover-bg !default;
 
 // $table-border-width:          $border-width !default;
@@ -820,7 +820,7 @@ $dropdown-border-radius:            .5rem;
 // $card-spacer-y:                     .75rem !default;
 // $card-spacer-x:                     1.25rem !default;
 // $card-border-width:                 $border-width !default;
-// $card-border-radius:                $border-radius !default;
+$card-border-radius:                .5rem;
 // $card-border-color:                 rgba($black, .125) !default;
 // $card-inner-border-radius:          calc(#{$card-border-radius} - #{$card-border-width}) !default;
 // $card-cap-bg:                       rgba($black, .03) !default;

--- a/src/scss/bridgeu/_tables.scss
+++ b/src/scss/bridgeu/_tables.scss
@@ -1,0 +1,21 @@
+//
+// Basic Bootstrap table
+//
+
+// Hover effect
+//
+// Placed here since it has to come after the potential zebra striping
+
+.table-hover {
+  tbody tr {
+    transition: $transition-base;
+
+    td:first-child, th:first-child {
+      border-radius: .5rem 0 0 .5rem;
+    }
+
+    td:last-child {
+      border-radius: 0 .5rem .5rem 0;
+    }
+  }
+}

--- a/src/scss/bridgeu/_tables.scss
+++ b/src/scss/bridgeu/_tables.scss
@@ -1,10 +1,6 @@
 //
-// Basic Bootstrap table
+// Nicer hover styles on top of Bootstrap's default
 //
-
-// Hover effect
-//
-// Placed here since it has to come after the potential zebra striping
 
 .table-hover {
   tbody tr {

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -349,6 +349,39 @@ storiesOf('Components', module)
       </div>
     </div>
   `)
+  .add('Tables', () => `
+    <div>
+
+    <h5>Hoverable Table</h5>
+    <div class="card shadow-sm p-2">
+      <table class="table table-borderless table-hover">
+        <thead>
+          <tr>
+            <th scope="col">First</th>
+            <th scope="col">Last</th>
+            <th scope="col">Email</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Harry</td>
+            <td>Potter</td>
+            <td>harry@hogwarts.com</td>
+          </tr>
+          <tr>
+            <td>Hermione</td>
+            <td>Granger</td>
+            <td>hermione@hogwarts.com</td>
+          </tr>
+          <tr>
+            <td>Ron</td>
+            <td>Weasley</td>
+            <td>ron@weasley.com</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  `)
   .add('Modals', () => `
     <div>
 


### PR DESCRIPTION
This PR adds an example of a table with hoverable rows, which is used in v2 Advisor UI. It also builds on top of Bootstrap's styles to provide nicer hover styles.

![image](https://user-images.githubusercontent.com/39978/73289735-231b3500-41f5-11ea-8d3d-f631171676b3.png)
