### PR TITLE
Replace absolute values with existing variables

### DIFF
--- a/src/scss/bridgeu/_tables.scss
+++ b/src/scss/bridgeu/_tables.scss
@@ -7,11 +7,11 @@
     transition: $transition-base;
 
     td:first-child, th:first-child {
-      border-radius: .5rem 0 0 .5rem;
+      border-radius: $card-border-radius 0 0 $card-border-radius;
     }
 
     td:last-child {
-      border-radius: 0 .5rem .5rem 0;
+      border-radius: 0 $card-border-radius $card-border-radius 0;
     }
   }
 }


### PR DESCRIPTION
Following @gnclmorais's [comment](https://github.com/BridgeU/bridget/pull/53#discussion_r373019463) on #53, replacing absolute values with existing variables.

No changes visually. This is how the table's hover effect looks.

![](https://user-images.githubusercontent.com/39978/73289735-231b3500-41f5-11ea-8d3d-f631171676b3.png)
