### PR TITLE
Add warning pill.

### DIFF
--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Lato);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700);
 @import url(https://fonts.googleapis.com/icon?family=Material+Icons);
 /*!
  * Bootstrap v4.3.1 (https://getbootstrap.com/)
@@ -7205,6 +7205,28 @@ a.text-dark:hover, a.text-dark:focus {
     .pill-success:not(:disabled):not(.disabled):active:focus, .pill-success:not(:disabled):not(.disabled).active:focus,
     .show > .pill-success.dropdown-toggle:focus {
       box-shadow: 0 0 0 0.2rem rgba(55, 176, 131, 0.5); }
+
+.pill-warning {
+  color: #ffc107;
+  border-color: #ffc107;
+  background: #fff4d3; }
+  .pill-warning:hover {
+    color: #ffc107;
+    background-color: #ffeeba;
+    border-color: #ffc107; }
+  .pill-warning:focus, .pill-warning.focus {
+    box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5); }
+  .pill-warning.disabled, .pill-warning:disabled {
+    color: #ffc107;
+    background-color: transparent; }
+  .pill-warning:not(:disabled):not(.disabled):active, .pill-warning:not(:disabled):not(.disabled).active,
+  .show > .pill-warning.dropdown-toggle {
+    color: #333333;
+    background-color: #ffeeba;
+    border-color: #ffc107; }
+    .pill-warning:not(:disabled):not(.disabled):active:focus, .pill-warning:not(:disabled):not(.disabled).active:focus,
+    .show > .pill-warning.dropdown-toggle:focus {
+      box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5); }
 
 .custom-select {
   -webkit-appearance: none;

--- a/src/scss/bridgeu/_pills.scss
+++ b/src/scss/bridgeu/_pills.scss
@@ -70,6 +70,11 @@ $pill-colors: (
     main: $success,
     background: lighten($success, 40%),
     active-background: lighten($success, 35%)
+  ),
+  warning: (
+    main: $warning,
+    background: lighten($warning, 40%),
+    active-background: lighten($warning, 35%)
   )
 ) !default;
 

--- a/src/stories/02-components.js
+++ b/src/stories/02-components.js
@@ -64,6 +64,11 @@ storiesOf('Components', module)
     <h5>Success pill</h5>
     <button type="button" class="pill pill-success">Success</button>
 
+    <div class="mb-5"></div>
+
+    <h5>Warning pill</h5>
+    <button type="button" class="pill pill-warning">Warning</button>
+
     <hr class="my-5" />
 
     <a href="https://getbootstrap.com/docs/4.3/components/buttons/#examples">


### PR DESCRIPTION
This PR adds the warning format on our CSS for the pill component, and also provides an example within Bridget.

![image](https://user-images.githubusercontent.com/3259932/89264148-bb75f480-d632-11ea-8f3e-84b7e12fd7f2.png)


