### PR TITLE
Fix Jquery version on the package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bridget",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6385,9 +6385,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridget",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "BridgeU style guide",
   "main": "dist/bridget.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "ui",
     "ux"
   ],
-  "author": "Gonçalo Morais <goncalo@bridge-u.com>",
+  "author": "Bridge-U Team <dev@bridge-u.com>",
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
-    "jquery": "^3.4.0",
+    "jquery": "3.4.1",
     "popper.js": "^1.14.7"
   }
 }


### PR DESCRIPTION
As we are using the Jquery ^3.4.0 versioning annotation, the library on `yarnupdate bridget` caused, to automatically install a double version of jquery into the dependant project, causing several parts of the dependent system to fail. until we fix/improve either briget or the dependent project setup. We propose to statically state the version of Jquery that we use.