### PR TITLE
Add new mixin and helper class for controlling Material icon size

### DIFF
--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -7093,8 +7093,32 @@ a.text-dark:hover, a.text-dark:focus {
   vertical-align: middle;
   margin-top: -0.25em; }
 
-.material-small {
+.material-xxxsmall {
+  font-size: 0.9375rem; }
+
+.material-xxsmall {
   font-size: 1.25rem; }
+
+.material-xsmall {
+  font-size: 1.5625rem; }
+
+.material-small {
+  font-size: 1.875rem; }
+
+.material-medium {
+  font-size: 2.1875rem; }
+
+.material-large {
+  font-size: 2.5rem; }
+
+.material-xlarge {
+  font-size: 3.75rem; }
+
+.material-xxlarge {
+  font-size: 5rem; }
+
+.material-xxxlarge {
+  font-size: 6.25rem; }
 
 .navbar-pills .nav-item {
   padding: 0.375rem 1.25rem;

--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -7093,6 +7093,9 @@ a.text-dark:hover, a.text-dark:focus {
   vertical-align: middle;
   margin-top: -0.25em; }
 
+.material-small {
+  font-size: 1.25rem; }
+
 .navbar-pills .nav-item {
   padding: 0.375rem 1.25rem;
   font-size: 0.875rem;

--- a/dist/bridget.css
+++ b/dist/bridget.css
@@ -7093,32 +7093,32 @@ a.text-dark:hover, a.text-dark:focus {
   vertical-align: middle;
   margin-top: -0.25em; }
 
-.material-xxxsmall {
-  font-size: 0.9375rem; }
+.u-material-size-15 {
+  font-size: 15px !important; }
 
-.material-xxsmall {
-  font-size: 1.25rem; }
+.u-material-size-20 {
+  font-size: 20px !important; }
 
-.material-xsmall {
-  font-size: 1.5625rem; }
+.u-material-size-25 {
+  font-size: 25px !important; }
 
-.material-small {
-  font-size: 1.875rem; }
+.u-material-size-30 {
+  font-size: 30px !important; }
 
-.material-medium {
-  font-size: 2.1875rem; }
+.u-material-size-35 {
+  font-size: 35px !important; }
 
-.material-large {
-  font-size: 2.5rem; }
+.u-material-size-40 {
+  font-size: 40px !important; }
 
-.material-xlarge {
-  font-size: 3.75rem; }
+.u-material-size-60 {
+  font-size: 60px !important; }
 
-.material-xxlarge {
-  font-size: 5rem; }
+.u-material-size-80 {
+  font-size: 80px !important; }
 
-.material-xxxlarge {
-  font-size: 6.25rem; }
+.u-material-size-100 {
+  font-size: 100px !important; }
 
 .navbar-pills .nav-item {
   padding: 0.375rem 1.25rem;

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -1,3 +1,6 @@
+// Helpers
+@import 'utilities/helpers';
+
 // BridgeU base customisations
 //
 // Prerequirements for Bootstrap customisation, like fonts and variables that

--- a/src/scss/bridgeu/_icons.scss
+++ b/src/scss/bridgeu/_icons.scss
@@ -1,5 +1,15 @@
 // Sizes of the Material icons (in px) present in Student UX
-$material-icon-small: 20;
+$material-icon-sizes: (
+  'xxxsmall': 15, 
+  'xxsmall': 20,
+  'xsmall': 25,
+  'small': 30,
+  'medium': 35,
+  'large': 40,
+  'xlarge': 60,
+  'xxlarge': 80,
+  'xxxlarge': 100
+);
 
 .material-icons {
   font-size: 1em;
@@ -7,7 +17,10 @@ $material-icon-small: 20;
   margin-top: -0.25em;
 }
 
-.material-small {
-  @include font-size($material-icon-small);
+@each $size, $value in $material-icon-sizes {
+  .material-#{$size} {
+    @include font-size($value);
+  }
 }
+
 

--- a/src/scss/bridgeu/_icons.scss
+++ b/src/scss/bridgeu/_icons.scss
@@ -1,5 +1,13 @@
+// Sizes of the Material icons (in px) present in Student UX
+$material-icon-small: 20;
+
 .material-icons {
   font-size: 1em;
   vertical-align: middle;
   margin-top: -0.25em;
 }
+
+.material-small {
+  @include font-size($material-icon-small);
+}
+

--- a/src/scss/bridgeu/_icons.scss
+++ b/src/scss/bridgeu/_icons.scss
@@ -1,15 +1,5 @@
 // Sizes of the Material icons (in px) present in Student UX
-$material-icon-sizes: (
-  'xxxsmall': 15, 
-  'xxsmall': 20,
-  'xsmall': 25,
-  'small': 30,
-  'medium': 35,
-  'large': 40,
-  'xlarge': 60,
-  'xxlarge': 80,
-  'xxxlarge': 100
-);
+$material-icon-sizes: ( 15, 20, 25, 30, 35, 40, 60, 80, 100 );
 
 .material-icons {
   font-size: 1em;
@@ -17,9 +7,9 @@ $material-icon-sizes: (
   margin-top: -0.25em;
 }
 
-@each $size, $value in $material-icon-sizes {
-  .material-#{$size} {
-    @include font-size($value);
+@each $icon-size in $material-icon-sizes {
+  .u-material-size-#{$icon-size} {
+    @include icon-size($icon-size);
   }
 }
 

--- a/src/scss/utilities/_helpers.scss
+++ b/src/scss/utilities/_helpers.scss
@@ -1,0 +1,13 @@
+//-------------------------------
+// Helpers
+//-------------------------------
+
+@mixin font-size($font-size) {
+  @if type-of($font-size) == number {
+    font-size: #{$font-size} + px !important;
+  }
+
+  @else {
+    @warn "Can only be used with numerical values";
+  }
+}

--- a/src/scss/utilities/_helpers.scss
+++ b/src/scss/utilities/_helpers.scss
@@ -2,9 +2,9 @@
 // Helpers
 //-------------------------------
 
-@mixin font-size($font-size) {
-  @if type-of($font-size) == number {
-    font-size: #{$font-size} + px !important;
+@mixin icon-size($icon-font-size) {
+  @if type-of($icon-font-size) == number {
+    font-size: $icon-font-size + px !important;
   }
 
   @else {


### PR DESCRIPTION
Adds a new mixin `font-size` which is primarily used for the Material icons but can be used in other contexts as well, as well as new helper classes which replaces the `md-<font size>` classes widely used across the Student portion of the app. 